### PR TITLE
Keep key format for CKAN___ env vars if they are declared

### DIFF
--- a/ckanext/envvars/plugin.py
+++ b/ckanext/envvars/plugin.py
@@ -54,6 +54,10 @@ class EnvvarsPlugin(plugins.SingletonPlugin):
 
         if config_declaration:
             self.declared_keys = [str(k) for k in config_declaration.iter_options()]
+            # SECRET_KEY is marked as internal in CKAN 2.10 but we want to
+            # encourage its use so we support it here
+            if "SECRET_KEY" not in self.declared_keys:
+                self.declared_keys.append("SECRET_KEY")
         else:
             self.declared_keys = None
 

--- a/ckanext/envvars/plugin.py
+++ b/ckanext/envvars/plugin.py
@@ -1,7 +1,13 @@
 import logging
 import os
+
 import ckan.plugins as plugins
 import ckantoolkit as toolkit
+
+if toolkit.check_ckan_version(min_version='2.10'):
+    from ckan.common import config_declaration
+else:
+    config_declaration = None
 
 
 log = logging.getLogger(__name__)
@@ -10,16 +16,31 @@ log = logging.getLogger(__name__)
 class EnvvarsPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
 
-    @staticmethod
-    def _envvar_to_ini(key):
+    # This is only used on CKAN>=2.10
+    declared_keys = None
+
+    def _envvar_to_ini(self, key):
         '''Transforms an env var formatted key to ini formatting.'''
+
+        def _format_key(key):
+            # Set it to lowercase
+            key = key.lower()
+            # Replace dunders with dots
+            key = key.replace('__', '.')
+
+            return key
+
         # If the key starts with 'CKAN___' (3 underscores).
         if key.startswith('CKAN___'):
             key = key[7:]
-        # Set it to lowercase
-        key = key.lower()
-        # Replace dunders with dots
-        key = key.replace('__', '.')
+
+        if self.declared_keys:
+            # If the key is defined as present in the env var, leave as is
+            # (eg uppercase)
+            if key not in self.declared_keys:
+                key = _format_key(key)
+        else:
+            key = _format_key(key)
 
         return key
 
@@ -31,6 +52,11 @@ class EnvvarsPlugin(plugins.SingletonPlugin):
         ckan_vars = ((k, v) for k, v in os.environ.items()
                      if k.startswith('CKAN'))
 
+        if config_declaration:
+            self.declared_keys = [str(k) for k in config_declaration.iter_options()]
+        else:
+            self.declared_keys = None
+
         # transform vars into ini settings format
         ckan_vars = ((self._envvar_to_ini(k), v) for k, v in ckan_vars)
 
@@ -38,6 +64,5 @@ class EnvvarsPlugin(plugins.SingletonPlugin):
         config.update(dict(ckan_vars))
 
         # CKAN >=2.10 normalizes config values
-        if toolkit.check_ckan_version(min_version='2.10'):
-            from ckan.common import config_declaration
+        if config_declaration:
             config_declaration.normalize(config)

--- a/ckanext/envvars/tests/test_base_envvars.py
+++ b/ckanext/envvars/tests/test_base_envvars.py
@@ -34,8 +34,24 @@ class TestEnvVarToIni(object):
         ]
 
         for envkey, inikey in envvar_to_ini_examples:
-            assert EnvvarsPlugin._envvar_to_ini(envkey) == inikey
+            assert EnvvarsPlugin()._envvar_to_ini(envkey) == inikey
 
+    @pytest.mark.skipif(tk.check_ckan_version(max_version='2.10'), reason="This does not apply to CKAN<2.10")
+    def test_envvartoini_expected_output_declared_option(self):
+        '''
+        EnvvarsPlugin._envvar_to_ini returns expected transformation of env
+        var formated keys
+        '''
+
+        envvar_to_ini_examples = [
+            ('CKAN___SECRET_KEY', 'SECRET_KEY'),
+            ('CKAN___REMEMBER_COOKIE_DURATION', 'REMEMBER_COOKIE_DURATION'),
+            ('CKAN___WTF_CSRF_ENABLED', 'WTF_CSRF_ENABLED'),
+            ('CKAN___NOT_DECLARED', 'not_declared'),
+        ]
+
+        for envkey, inikey in envvar_to_ini_examples:
+            assert EnvvarsPlugin()._envvar_to_ini(envkey) == inikey
 
 class TestEnvVarsConfig(object):
 
@@ -68,6 +84,25 @@ class TestEnvVarsConfig(object):
         assert tk.config['ckanext.another.ext_setting'] == 'my-other-extension-value'
         assert tk.config['beaker.session.key'] == 'my-beaker-key'
         assert tk.config['cache_dir'] == '/cache_directory_path/'
+
+        self._teardown_env_vars(envvar_to_ini_examples)
+
+    @pytest.mark.skipif(tk.check_ckan_version(max_version='2.10'), reason="This does not apply to CKAN<2.10")
+    def test_envvars_values_in_config(self):
+
+        envvar_to_ini_examples = [
+            ('CKAN___SECRET_KEY', 'super_secret'),
+            ('CKAN___REMEMBER_COOKIE_DURATION', '1000'),
+            ('CKAN___WTF_CSRF_ENABLED', 'True'),
+            ('CKAN___NOT_DECLARED', 'test'),
+        ]
+
+        self._setup_env_vars(envvar_to_ini_examples)
+
+        assert tk.config['SECRET_KEY'] == 'super_secret'
+        assert tk.config['REMEMBER_COOKIE_DURATION'] == 1000
+        assert tk.config['WTF_CSRF_ENABLED'] == True
+        assert tk.config['not_declared'] == 'test'
 
         self._teardown_env_vars(envvar_to_ini_examples)
 


### PR DESCRIPTION
If a config key is declared in the CKAN config declaration, the key is not further processed. This allows to keep eg upper case setttings like SECRET_KEY, WTF_CSRF_ENABLED etc:

    CKAN___SECRET_KEY=xxx -> config["SECRET_KEY"] = 'xxx'
    CKAN___WTF_CSRF_ENABLED=True -> config["WTF_CSRF_ENABLED"] = True